### PR TITLE
Revert "fix: remove vesting_balance_type from vesting_balance_withdraw_operation"

### DIFF
--- a/lib/serializer/src/operations.js
+++ b/lib/serializer/src/operations.js
@@ -1110,7 +1110,8 @@ const vesting_balance_withdraw = new Serializer('vesting_balance_withdraw', {
   fee: asset,
   vesting_balance: protocol_id_type('vesting_balance'),
   owner: protocol_id_type('account'),
-  amount: asset
+  amount: asset,
+  balance_type: vesting_balance_type
 });
 
 const refund_worker_initializer = new Serializer('refund_worker_initializer');


### PR DESCRIPTION
Reverts peerplays-network/peerplaysjs-lib#37 because changes in a pre-release (alpha) should not be merged to master branch withou end-to-end QA.